### PR TITLE
fix: example's BGFX initialization

### DIFF
--- a/examples/graphics.nim
+++ b/examples/graphics.nim
@@ -130,9 +130,9 @@ proc init*(graphics: Graphics, title: string, width, height: int, flags: uint32)
     echo "Error creating SDL2 window."
     quit(QUIT_FAILURE)
 
-  # Call bgfx::renderFrame before bgfx::init to signal to bgfx not to create a render thread.
-  # Most graphics APIs must be used on the same thread that created the window.
-  discard bgfx_render_frame(-1)
+  # # Call bgfx::renderFrame before bgfx::init to signal to bgfx not to create a render thread.
+  # # Most graphics APIs must be used on the same thread that created the window.
+  # discard bgfx_render_frame(-1)
 
   var init: bgfx_init_t
 


### PR DESCRIPTION
I wondered why example hello world is not working, and I found solution.
I confirmed bgfx initialization method is changed recently (I don't know when it changed).